### PR TITLE
Add missing policy to allow redis-master-slave communication

### DIFF
--- a/guestbook-netpolicy.yaml
+++ b/guestbook-netpolicy.yaml
@@ -1,31 +1,48 @@
-apiVersion: extensions/v1beta1                                                                                                                                                                              
-kind: NetworkPolicy                                                                                                                                                                                         
-metadata:                                                                                                                                                                                                   
- name: gb-external-frontend                                                                                                                                                                             
-spec:                                                                                                                                                                                                       
- podSelector:                                                                                                                                                                                               
-  matchLabels:                                                                                                                                                                                              
-    tier: frontend                                                                                                                                                                                          
- ingress:                                                                                                                                                                                                   
-  - from:                                                                                                                                                                                                   
-    ports:                                                                                                                                                                                                    
-    - protocol: TCP                                                                                                                                                                                        
-      port: 80                                                                                                                                                                                             
----                                                                                                                                                                                                         
-apiVersion: extensions/v1beta1                                                                                                                                                                              
-kind: NetworkPolicy                                                                                                                                                                                         
-metadata:                                                                                                                                                                                                   
- name: gb-frontend-backend                                                                                                                                                                              
-spec:                                                                                                                                                                                                       
- podSelector:                                                                                                                                                                                               
-  matchLabels:                                                                                                                                                                                              
-    tier: backend                                                                                                                                                                                           
- ingress:                                                                                                                                                                                                   
-  - from:                                                                                                                                                                                                   
-     - podSelector:                                                                                                                                                                                         
-        matchLabels:                                                                                                                                                                                        
-          tier: frontend                                                                                                                                                                                    
-          app: guestbook                                                                                                                                                                                    
-    ports:                                                                                                                                                                                                  
-     - protocol: TCP                                                                                                                                                                                        
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+ name: gb-external-frontend
+spec:
+ podSelector:
+  matchLabels:
+    tier: frontend
+ ingress:
+  - from:
+    ports:
+    - protocol: TCP
+      port: 80
+---
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+ name: gb-frontend-backend
+spec:
+ podSelector:
+  matchLabels:
+    tier: backend
+ ingress:
+  - from:
+     - podSelector:
+        matchLabels:
+          tier: frontend
+          app: guestbook
+    ports:
+     - protocol: TCP
+       port: 6379
+---
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+ name: gb-backend-backend
+spec:
+ podSelector:
+  matchLabels:
+    tier: backend
+ ingress:
+  - from:
+     - podSelector:
+        matchLabels:
+          tier: backend
+    ports:
+     - protocol: TCP
        port: 6379


### PR DESCRIPTION
Original issue we found was the missing persistence of newly entered guestbook entries after applying the network policy rule. 

### Reproduction

- follow test plan until guestbook application is deployed
- play with deployed guestbook app, entering items and refreshing the page afterwards. (entered items show up)
- apply (old) `guestbook-netpolicy.yaml`
- play with deployed guestbook app, entering items. The page behaves as expected in a first place, but after browser refresh the newly entered items disappear.

It seems the communication from frontend to redis backend works, but the applied network policies deny sync between redis master and slaves.